### PR TITLE
Fix isort/black and flake8/black conflicts

### DIFF
--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -1,7 +1,6 @@
 [flake8]
-max-line-length = 80
 exclude = .tox,.git,*/migrations/*,docs,node_modules,venv,data
-extend-ignore = E203
+extend-ignore = E203,E501
 
 [isort]
 line_length = 80

--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -5,10 +5,7 @@ extend-ignore = E203,E501
 [isort]
 line_length = 80
 known_first_party = {{ cookiecutter.code_directory }}
-multi_line_output = 3
+profile = black
 default_section = THIRDPARTY
 skip = venv/
 skip_glob = **/migrations/*.py
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true


### PR DESCRIPTION
This PR addresses conflicts between code formatting tools `isort`, `black`, and `flake8` in our template. Specifically, it resolves issues where these tools have conflicting rules or behaviors (previously there was a black/isort and a black/flake8 conflict). In both cases, I have chosen to follow black's defaults.