### PR TITLE
Update workflow to run pytest on doctests and report on coverage

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/main.workflow.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/main.workflow.yml
@@ -25,3 +25,43 @@ jobs:
             requirements.txt
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with pre-commit
+        uses: pre-commit/action@v3.0.0
+      - name: Run Pytest
+        run: |
+          # coverage run on pytest. If pytest fails, workflow exits in failure
+          coverage run -m pytest --doctest-modules
+          coverage json
+          export TOTAL=$(python -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
+          echo "total=$TOTAL" >> $GITHUB_ENV
+          coverage report -m --format=markdown >> temp.md
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          {
+            echo 'REPORT<<EOF'
+            cat temp.md
+            echo EOF
+          } >> "$GITHUB_ENV"
+          echo "report=$REPORT" >> $GITHUB_ENV
+      - name: Report Coverage
+        uses: actions/github-script@v7
+        env:
+          min_coverage: 50
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${{ env.REPORT }}`
+            })
+            if ( ${{ env.total }} <= ${{ env.min_coverage }} ) { 
+              console.log(
+                "Coverage test failed as code coverage is ${{ env.total }}% and the minimum is ${{ env.min_coverage}}%"
+              )
+              process.exitCode = 1 
+            }
+

--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -2,6 +2,8 @@
 flake8~=4.0
 black~=22.1
 pre-commit~=2.20
+pytest~=7.4
+coverage~=7.3
 ipykernel~=6.16
 
 # project packages


### PR DESCRIPTION
Closes #23 

Creates workflow that runs pytest + doctest and checks coverage. If coverage is less than pre-defined threshold, fails checker. Otherwise reports coverage (and missing lines) in PR comment